### PR TITLE
Makefile: remove unused dependencies

### DIFF
--- a/terraform-provider-{{ cookiecutter.cloud_provider.lower().replace(' ', '-') }}/Makefile
+++ b/terraform-provider-{{ cookiecutter.cloud_provider.lower().replace(' ', '-') }}/Makefile
@@ -115,7 +115,7 @@ $(SPEAKEASY_BINARY):
 	mkdir -p $(@D)
 	cd $(@D) && curl https://github.com/speakeasy-api/speakeasy/releases/download/v1.129.1/speakeasy_$(OS)_$(ARCH).zip -L -o speakeasy.zip && unzip -o speakeasy.zip $(@F) && rm speakeasy.zip ; chmod +x $(@F)
 
-{{ cookiecutter.cloud_provider.lower().replace(' ', '-') }}.yaml: $(GOJSONTOYAML_BINARY) $(YQ_BINARY) patch.sh
+{{ cookiecutter.cloud_provider.lower().replace(' ', '-') }}.yaml: patch.sh
 	curl {{ cookiecutter.openapi_specification_url }} | sh patch.sh > $@
 
 $(SPEAKEASY_FILES) files.gen &: {{ cookiecutter.cloud_provider.lower().replace(' ', '-') }}.yaml $(SPEAKEASY_BINARY)


### PR DESCRIPTION
This commit removes unused dependencies from targets in the Makefile.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
